### PR TITLE
Update panel type, add hostname & cluster dropdown, fix jsonnet typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.gitignore
+.vscode/settings.json
+vsan-prometheus-servicediscovery/bearer-token
+vsan-prometheus-servicediscovery/vsan_sd.json
+vsan-prometheus-setup/__pycache__/vsanapiutils.cpython-310.pyc
+vsan-prometheus-setup/__pycache__/vsanmgmtObjects.cpython-310.pyc

--- a/grafana-dashboard/dashboards/grafana-dashboard-cpu.json
+++ b/grafana-dashboard/dashboards/grafana-dashboard-cpu.json
@@ -62,6 +62,7 @@
          "targets": [
             {
                "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"DOM\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"DOM\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -114,7 +115,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"DOM\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"DOM\"}[1m])) * 100",
+         "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"DOM\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"DOM\"}[1m])) * 100",
          "fill": 1,
          "fillGradient": 0,
          "format": "percent",
@@ -151,7 +152,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"DOM\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"DOM\"}[1m])) * 100",
+               "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"DOM\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"DOM\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -242,6 +244,7 @@
          "targets": [
             {
                "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"LLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"LLOG\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -294,7 +297,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"LLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"LLOG\"}[1m])) * 100",
+         "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"LLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"LLOG\"}[1m])) * 100",
          "fill": 1,
          "fillGradient": 0,
          "format": "percent",
@@ -331,7 +334,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"LLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"LLOG\"}[1m])) * 100",
+               "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"LLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"LLOG\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -422,6 +426,7 @@
          "targets": [
             {
                "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"PLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"PLOG\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -474,7 +479,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"PLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"PLOG\"}[1m])) * 100",
+         "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"PLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"PLOG\"}[1m])) * 100",
          "fill": 1,
          "fillGradient": 0,
          "format": "percent",
@@ -511,7 +516,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"PLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"PLOG\"}[1m])) * 100",
+               "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"PLOG\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"PLOG\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -602,6 +608,7 @@
          "targets": [
             {
                "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"Network\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"Network\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -654,7 +661,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"Network\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"Network\"}[1m])) * 100",
+         "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"Network\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"Network\"}[1m])) * 100",
          "fill": 1,
          "fillGradient": 0,
          "format": "percent",
@@ -691,7 +698,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"Network\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"Network\"}[1m])) * 100",
+               "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"Network\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"Network\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -782,6 +790,7 @@
          "targets": [
             {
                "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"CMMDS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"CMMDS\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -834,7 +843,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"CMMDS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"CMMDS\"}[1m])) * 100",
+         "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"CMMDS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"CMMDS\"}[1m])) * 100",
          "fill": 1,
          "fillGradient": 0,
          "format": "percent",
@@ -871,7 +880,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(5, rate(vmware_esx_world_readytime_seconds_total{subsystem=\"CMMDS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"CMMDS\"}[1m])) * 100",
+               "expr": "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"CMMDS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"CMMDS\"}[1m])) * 100",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -926,7 +936,50 @@
       "vsan"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "MKCZcgjnz"
+            },
+            "definition": "label_values(cluster_name)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "Cluster",
+            "options": [ ],
+            "query": {
+               "query": "label_values(cluster_name)",
+               "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "MKCZcgjnz"
+            },
+            "definition": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "hostname",
+            "options": [ ],
+            "query": {
+               "query": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+               "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
    },
    "time": {
       "from": "now-1h",

--- a/grafana-dashboard/dashboards/grafana-dashboard-domdg.json
+++ b/grafana-dashboard/dashboards/grafana-dashboard-domdg.json
@@ -24,7 +24,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -36,20 +36,14 @@
          },
          "hiddenSeries": false,
          "id": 10,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -61,7 +55,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -75,7 +70,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -114,7 +109,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -126,20 +121,14 @@
          },
          "hiddenSeries": false,
          "id": 11,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -151,7 +140,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -165,7 +155,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -204,7 +194,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -216,20 +206,14 @@
          },
          "hiddenSeries": false,
          "id": 20,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -241,7 +225,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -255,7 +240,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -294,7 +279,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -306,20 +291,14 @@
          },
          "hiddenSeries": false,
          "id": 21,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -331,7 +310,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -345,7 +325,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -384,7 +364,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "bytes",
@@ -396,20 +376,14 @@
          },
          "hiddenSeries": false,
          "id": 30,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -421,7 +395,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -435,7 +410,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -474,7 +449,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "bytes",
@@ -486,20 +461,14 @@
          },
          "hiddenSeries": false,
          "id": 31,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -511,7 +480,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -525,7 +495,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -564,7 +534,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -576,20 +546,14 @@
          },
          "hiddenSeries": false,
          "id": 40,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -601,7 +565,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -615,7 +580,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -654,7 +619,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -666,20 +631,14 @@
          },
          "hiddenSeries": false,
          "id": 41,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -691,7 +650,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -705,7 +665,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -744,7 +704,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -756,20 +716,14 @@
          },
          "hiddenSeries": false,
          "id": 50,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -781,7 +735,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -795,7 +750,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -834,7 +789,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -846,20 +801,14 @@
          },
          "hiddenSeries": false,
          "id": 51,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -871,7 +820,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid,io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -885,7 +835,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -924,7 +874,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(vmware_vsan_disk_writebuffer_usage_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid) / sum(vmware_vsan_disk_writebuffer_size_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid)",
+         "expr": "sum(vmware_vsan_disk_writebuffer_usage_bytes{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid) / sum(vmware_vsan_disk_writebuffer_size_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid)",
          "fill": 1,
          "fillGradient": 0,
          "format": "percentunit",
@@ -936,20 +886,14 @@
          },
          "hiddenSeries": false,
          "id": 60,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -961,7 +905,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(vmware_vsan_disk_writebuffer_usage_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid) / sum(vmware_vsan_disk_writebuffer_size_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid)",
+               "expr": "sum(vmware_vsan_disk_writebuffer_usage_bytes{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid) / sum(vmware_vsan_disk_writebuffer_size_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -975,7 +920,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1014,7 +959,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "rate(vmware_vsan_disk_drain_bytes_total{disk_role=\"cache\"}[1m])",
+         "expr": "rate(vmware_vsan_disk_drain_bytes_total{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -1026,20 +971,14 @@
          },
          "hiddenSeries": false,
          "id": 61,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, drain_type={{drain_type}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1051,7 +990,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "rate(vmware_vsan_disk_drain_bytes_total{disk_role=\"cache\"}[1m])",
+               "expr": "rate(vmware_vsan_disk_drain_bytes_total{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])",
+               "legendFormat": "{{hostname}}, drain_type={{drain_type}}",
                "refId": "A"
             }
          ],
@@ -1065,7 +1005,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1104,7 +1044,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(vmware_vsan_disk_congestion_total{disk_role=\"cache\"}) by (hostname, disk_uuid, congestion_type)",
+         "expr": "sum(vmware_vsan_disk_congestion_total{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid, congestion_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1116,20 +1056,14 @@
          },
          "hiddenSeries": false,
          "id": 62,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_role={{disk_role}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1141,7 +1075,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(vmware_vsan_disk_congestion_total{disk_role=\"cache\"}) by (hostname, disk_uuid, congestion_type)",
+               "expr": "sum(vmware_vsan_disk_congestion_total{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid, congestion_type)",
+               "legendFormat": "{{hostname}}, disk_role={{disk_role}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -1155,7 +1090,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1194,7 +1129,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(vmware_vsan_disk_congestion_bytespersecond{disk_role=\"cache\"}) by (hostname, disk_uuid)",
+         "expr": "sum(vmware_vsan_disk_congestion_bytespersecond{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -1206,20 +1141,14 @@
          },
          "hiddenSeries": false,
          "id": 63,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1231,7 +1160,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(vmware_vsan_disk_congestion_bytespersecond{disk_role=\"cache\"}) by (hostname, disk_uuid)",
+               "expr": "sum(vmware_vsan_disk_congestion_bytespersecond{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1245,7 +1175,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1286,7 +1216,50 @@
       "vsan"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "MKCZcgjnz"
+            },
+            "definition": "label_values(cluster_name)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "Cluster",
+            "options": [ ],
+            "query": {
+               "query": "label_values(cluster_name)",
+               "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "MKCZcgjnz"
+            },
+            "definition": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "hostname",
+            "options": [ ],
+            "query": {
+               "query": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+               "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
    },
    "time": {
       "from": "now-1h",

--- a/grafana-dashboard/dashboards/grafana-dashboard-layers.json
+++ b/grafana-dashboard/dashboards/grafana-dashboard-layers.json
@@ -24,7 +24,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -36,20 +36,14 @@
          },
          "hiddenSeries": false,
          "id": 10,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -61,7 +55,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -75,7 +70,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -114,7 +109,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -126,20 +121,14 @@
          },
          "hiddenSeries": false,
          "id": 11,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -151,7 +140,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -165,7 +155,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -204,7 +194,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -216,20 +206,14 @@
          },
          "hiddenSeries": false,
          "id": 12,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -241,7 +225,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -255,7 +240,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -294,7 +279,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -306,20 +291,14 @@
          },
          "hiddenSeries": false,
          "id": 13,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -331,7 +310,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -345,7 +325,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -384,7 +364,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -396,20 +376,14 @@
          },
          "hiddenSeries": false,
          "id": 14,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -421,7 +395,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -435,7 +410,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -474,7 +449,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -486,20 +461,14 @@
          },
          "hiddenSeries": false,
          "id": 15,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -511,7 +480,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ownerLeaf\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -525,7 +495,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -564,7 +534,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -576,20 +546,14 @@
          },
          "hiddenSeries": false,
          "id": 16,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -601,7 +565,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"read\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -615,7 +580,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -654,7 +619,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -666,20 +631,14 @@
          },
          "hiddenSeries": false,
          "id": 17,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -691,7 +650,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"write\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\"}[1m]) +1) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -705,7 +665,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -744,7 +704,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -756,20 +716,14 @@
          },
          "hiddenSeries": false,
          "id": 18,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -781,7 +735,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -795,7 +750,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -834,7 +789,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -846,20 +801,14 @@
          },
          "hiddenSeries": false,
          "id": 19,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -871,7 +820,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -885,7 +835,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -924,7 +874,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -936,20 +886,14 @@
          },
          "hiddenSeries": false,
          "id": 20,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -961,7 +905,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -975,7 +920,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1014,7 +959,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -1026,20 +971,14 @@
          },
          "hiddenSeries": false,
          "id": 21,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1051,7 +990,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -1065,7 +1005,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1104,7 +1044,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -1116,20 +1056,14 @@
          },
          "hiddenSeries": false,
          "id": 22,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1141,7 +1075,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"read\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -1155,7 +1090,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1194,7 +1129,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "s",
@@ -1206,20 +1141,14 @@
          },
          "hiddenSeries": false,
          "id": 23,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1231,7 +1160,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"write\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"capacity\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -1245,7 +1175,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1284,7 +1214,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1296,20 +1226,14 @@
          },
          "hiddenSeries": false,
          "id": 30,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1321,7 +1245,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1335,7 +1260,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1374,7 +1299,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1386,20 +1311,14 @@
          },
          "hiddenSeries": false,
          "id": 31,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1411,7 +1330,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1425,7 +1345,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1464,7 +1384,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1476,20 +1396,14 @@
          },
          "hiddenSeries": false,
          "id": 32,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1501,7 +1415,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1515,7 +1430,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1554,7 +1469,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1566,20 +1481,14 @@
          },
          "hiddenSeries": false,
          "id": 33,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1591,7 +1500,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1605,7 +1515,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1644,7 +1554,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1656,20 +1566,14 @@
          },
          "hiddenSeries": false,
          "id": 34,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1681,7 +1585,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1695,7 +1600,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1734,7 +1639,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1746,20 +1651,14 @@
          },
          "hiddenSeries": false,
          "id": 35,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1771,7 +1670,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"ownerLeaf\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1785,7 +1685,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -1824,7 +1724,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1836,20 +1736,14 @@
          },
          "hiddenSeries": false,
          "id": 36,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1861,7 +1755,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1875,7 +1770,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -1914,7 +1809,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -1926,20 +1821,14 @@
          },
          "hiddenSeries": false,
          "id": 37,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -1951,7 +1840,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -1965,7 +1855,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -2004,7 +1894,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -2016,20 +1906,14 @@
          },
          "hiddenSeries": false,
          "id": 38,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2041,7 +1925,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -2055,7 +1940,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -2094,7 +1979,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -2106,20 +1991,14 @@
          },
          "hiddenSeries": false,
          "id": 39,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2131,7 +2010,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -2145,7 +2025,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -2184,7 +2064,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -2196,20 +2076,14 @@
          },
          "hiddenSeries": false,
          "id": 40,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2221,7 +2095,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -2235,7 +2110,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -2274,7 +2149,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -2286,20 +2161,14 @@
          },
          "hiddenSeries": false,
          "id": 41,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2311,7 +2180,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -2325,7 +2195,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -2364,7 +2234,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -2376,20 +2246,14 @@
          },
          "hiddenSeries": false,
          "id": 42,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2401,7 +2265,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -2415,7 +2280,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -2454,7 +2319,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -2466,20 +2331,14 @@
          },
          "hiddenSeries": false,
          "id": 43,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2491,7 +2350,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"capacity\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -2505,7 +2365,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -2544,7 +2404,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -2556,20 +2416,14 @@
          },
          "hiddenSeries": false,
          "id": 50,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2581,7 +2435,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -2595,7 +2450,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -2634,7 +2489,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -2646,20 +2501,14 @@
          },
          "hiddenSeries": false,
          "id": 51,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2671,7 +2520,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"client\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -2685,7 +2535,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -2724,7 +2574,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -2736,20 +2586,14 @@
          },
          "hiddenSeries": false,
          "id": 52,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2761,7 +2605,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -2775,7 +2620,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -2814,7 +2659,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -2826,20 +2671,14 @@
          },
          "hiddenSeries": false,
          "id": 53,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2851,7 +2690,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"owner\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -2865,7 +2705,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -2904,7 +2744,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -2916,20 +2756,14 @@
          },
          "hiddenSeries": false,
          "id": 54,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -2941,7 +2775,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"read\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -2955,7 +2790,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -2994,7 +2829,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+         "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3006,20 +2841,14 @@
          },
          "hiddenSeries": false,
          "id": 55,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3031,7 +2860,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"write\"}[1m])) by (hostname, io_type, role)",
+               "expr": "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"compmgr\", io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3045,7 +2875,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -3084,7 +2914,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3096,20 +2926,14 @@
          },
          "hiddenSeries": false,
          "id": 56,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3121,7 +2945,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3135,7 +2960,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -3174,7 +2999,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3186,20 +3011,14 @@
          },
          "hiddenSeries": false,
          "id": 57,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3211,7 +3030,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3225,7 +3045,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -3264,7 +3084,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3276,20 +3096,14 @@
          },
          "hiddenSeries": false,
          "id": 58,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3301,7 +3115,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3315,7 +3130,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -3354,7 +3169,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3366,20 +3181,14 @@
          },
          "hiddenSeries": false,
          "id": 59,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3391,7 +3200,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"cache\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3405,7 +3215,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -3444,7 +3254,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3456,20 +3266,14 @@
          },
          "hiddenSeries": false,
          "id": 60,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3481,7 +3285,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"read\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"read\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -3495,7 +3300,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -3534,7 +3339,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+         "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
          "fill": 1,
          "fillGradient": 0,
          "format": "Bps",
@@ -3546,20 +3351,14 @@
          },
          "hiddenSeries": false,
          "id": 61,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}, disk_uuid={{disk_uuid}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3571,7 +3370,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"write\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "expr": "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"capacity\",io_type=\"write\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+               "legendFormat": "{{hostname}}, disk_uuid={{disk_uuid}}",
                "refId": "A"
             }
          ],
@@ -3585,7 +3385,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 12,
          "xaxis": {
             "buckets": null,
@@ -3624,7 +3424,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"client\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\"}[1m]) +1) by (hostname, role)",
+         "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"client\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -3636,20 +3436,14 @@
          },
          "hiddenSeries": false,
          "id": 70,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3661,7 +3455,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"client\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\"}[1m]) +1) by (hostname, role)",
+               "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"client\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"client\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3675,7 +3470,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -3714,7 +3509,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"owner\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\"}[1m]) +1) by (hostname, role)",
+         "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"owner\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -3726,20 +3521,14 @@
          },
          "hiddenSeries": false,
          "id": 72,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3751,7 +3540,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"owner\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\"}[1m]) +1) by (hostname, role)",
+               "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"owner\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"owner\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3765,7 +3555,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -3804,7 +3594,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": null,
-         "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"compmgr\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\"}[1m]) +1) by (hostname, role)",
+         "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"compmgr\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)",
          "fill": 1,
          "fillGradient": 0,
          "format": "short",
@@ -3816,20 +3606,14 @@
          },
          "hiddenSeries": false,
          "id": 74,
-         "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-         },
+         "legend": "{{hostname}}",
          "lines": true,
          "linewidth": 1,
          "nullPointMode": "null",
          "options": {
-            "dataLinks": [ ]
+            "dataLinks": [ ],
+            "displayMode": "list",
+            "placement": "bottom"
          },
          "percentage": false,
          "pointradius": 2,
@@ -3841,7 +3625,8 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"compmgr\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\"}[1m]) +1) by (hostname, role)",
+               "expr": "sum(rate(vmware_vsan_dom_numoio_total{role=\"compmgr\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"compmgr\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)",
+               "legendFormat": "{{hostname}}",
                "refId": "A"
             }
          ],
@@ -3855,7 +3640,7 @@
             "sort": 0,
             "value_type": "individual"
          },
-         "type": "graph",
+         "type": "timeseries",
          "x": 0,
          "xaxis": {
             "buckets": null,
@@ -3896,7 +3681,50 @@
       "vsan"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "MKCZcgjnz"
+            },
+            "definition": "label_values(cluster_name)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "Cluster",
+            "options": [ ],
+            "query": {
+               "query": "label_values(cluster_name)",
+               "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "MKCZcgjnz"
+            },
+            "definition": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "hostname",
+            "options": [ ],
+            "query": {
+               "query": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+               "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
    },
    "time": {
       "from": "now-1h",

--- a/grafana-dashboard/grafana-dashboard-cpu.jsonnet
+++ b/grafana-dashboard/grafana-dashboard-cpu.jsonnet
@@ -24,7 +24,7 @@ local LayersPanels(id, y, title, format, expr) =
 
 local panels = 
   LayersPanels(10, 0, "Top-5 CPU Utilization", "percent", 
-    "topk(5, rate(vmware_esx_world_uptime_seconds_total{subsystem=\"SUBSYS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"SUBSYS\"}[1m])) * 100");
+    "topk(5, rate(vmware_esx_world_usedtime_seconds_total{subsystem=\"SUBSYS\"}[1m]) / rate(vmware_esx_world_uptime_seconds_total{subsystem=\"SUBSYS\"}[1m])) * 100");
 
    # XXX: Add all the missing ones
 

--- a/grafana-dashboard/grafana-dashboard-domdg.jsonnet
+++ b/grafana-dashboard/grafana-dashboard-domdg.jsonnet
@@ -1,48 +1,42 @@
 local lib = import 'grafana-dashboard-func.libsonnet';
 
-local OnePanel(id, x, y, title, format, expr) = [
+local OnePanel(id, x, y, title, format, expr, legend) = [
    lib.Panel{
      id: id, x: x, y: y, 
      title: title, 
      format: format,
-     expr: expr
+     expr: expr,
+     legend: legend
    }
 ];
 
-local ReadWritePanels(id, y, title, format, expr) = [
+local ReadWritePanels(id, y, title, format, expr, legend) = [
    lib.Panel{
      id: id, x: 0, y: y, 
      title: title + " (Read)", 
      format: format,
-     expr: std.strReplace(std.strReplace(expr, "LSOMIOTYPE", "Read"), "IOTYPE", "read")
+     expr: std.strReplace(std.strReplace(expr, "LSOMIOTYPE", "Read"), "IOTYPE", "read"),
+     legend: legend
    },
    lib.Panel{
      id: id + 1, x: 12, y: y, 
      title: title + " (Write)", 
      format: format,
-     expr: std.strReplace(std.strReplace(expr,  "LSOMIOTYPE", "Write"), "IOTYPE", "write")
+     expr: std.strReplace(std.strReplace(expr,  "LSOMIOTYPE", "Write"), "IOTYPE", "write"),
+     legend: legend
    },
 ];
 
 local panels = 
-  ReadWritePanels(10, 0, "DOM DG IOPS", "short",
-    "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid,io_type)") +
-  ReadWritePanels(20, 8, "DOM DG Tput", "Bps",
-    "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid,io_type)") + 
-  ReadWritePanels(30, 16, "DOM DG Avg IO Size", "bytes",
-    "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid,io_type)") +
-  ReadWritePanels(40, 24, "DOM DG Latency", "s",
-    "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid,io_type)") +
-  ReadWritePanels(50, 32, "DOM DG Outstanding IO (QD)", "short",
-    "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid,io_type)") +
-  OnePanel(60, 0, 40, "Write Buffer", "percentunit",
-    "sum(vmware_vsan_disk_writebuffer_usage_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid) / sum(vmware_vsan_disk_writebuffer_size_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid)") +
-  OnePanel(61, 12, 40, "WB Drain/Destage Rate", "Bps",
-    "rate(vmware_vsan_disk_drain_bytes_total{disk_role=\"cache\"}[1m])") +
-  OnePanel(62, 0, 48, "Congestion (0-255)", "short",
-    "sum(vmware_vsan_disk_congestion_total{disk_role=\"cache\"}) by (hostname, disk_uuid, congestion_type)") +
-  OnePanel(63, 12, 48, "Congestion (Tput based)", "Bps",
-    "sum(vmware_vsan_disk_congestion_bytespersecond{disk_role=\"cache\"}) by (hostname, disk_uuid)");
+  ReadWritePanels(10, 0, "DOM DG IOPS", "short", "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)", "{{hostname}}") +
+  ReadWritePanels(20, 8, "DOM DG Tput", "Bps", "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type)", "{{hostname}}") + 
+  ReadWritePanels(30, 16, "DOM DG Avg IO Size", "bytes", "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid,io_type)", "{{hostname}}") +
+  ReadWritePanels(40, 24, "DOM DG Latency", "s", "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid,io_type)", "{{hostname}}") +
+  ReadWritePanels(50, 32, "DOM DG Outstanding IO (QD)", "short", "sum(rate(vmware_vsan_domdg_numoio_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid,io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid,io_type)", "{{hostname}}") +
+  OnePanel(60, 0, 40, "Write Buffer", "percentunit", "sum(vmware_vsan_disk_writebuffer_usage_bytes{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid) / sum(vmware_vsan_disk_writebuffer_size_bytes{disk_role=\"cache\"}) by (hostname, disk_uuid)", "{{hostname}}") +
+  OnePanel(61, 12, 40, "WB Drain/Destage Rate", "Bps", "rate(vmware_vsan_disk_drain_bytes_total{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])", "{{hostname}}, drain_type={{drain_type}}") +
+  OnePanel(62, 0, 48, "Congestion (0-255)", "short", "sum(vmware_vsan_disk_congestion_total{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid, congestion_type)", "{{hostname}}, disk_role={{disk_role}}, disk_uuid={{disk_uuid}}") +
+  OnePanel(63, 12, 48, "Congestion (Tput based)", "Bps", "sum(vmware_vsan_disk_congestion_bytespersecond{disk_role=\"cache\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}) by (hostname, disk_uuid)", "{{hostname}}");
 
 
 lib.Dashboard{

--- a/grafana-dashboard/grafana-dashboard-func.libsonnet
+++ b/grafana-dashboard/grafana-dashboard-func.libsonnet
@@ -1,140 +1,187 @@
 {
-   "Panel": {
-      local panel = self,
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": panel.x,
-        "y": panel.y
+  "Panel": {
+        local panel = self,
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": null,
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": panel.x,
+      "y": panel.y
+    },
+    "hiddenSeries": false,
+    "id": panel.id,
+    "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "nullPointMode": "null",
+    "options": {
+      "dataLinks": [],
+      "displayMode": "list",
+      "placement": "bottom",
+    },
+    "percentage": false,
+    "pointradius": 2,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+      {
+        "expr": panel.expr,
+        "refId": "A",
+        #"legendFormat": "{{hostname}}"
+        "legendFormat": panel.legend
+      }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": panel.title,
+    "tooltip": {
+      "shared": true,
+      "sort": 0,
+      "value_type": "individual"
+    },
+    "type": "timeseries",
+    "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": []
+    },
+    "yaxes": [
+      {
+        "format": panel.format,
+        "label": "",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
       },
-      "hiddenSeries": false,
-      "id": panel.id,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    ],
+    "yaxis": {
+      "align": false,
+      "alignLevel": null
+    }
+  },
+  "Dashboard": {
+        local dash = self,
+    "annotations": {
+      "list": [
         {
-          "expr": panel.expr,
-          "refId": "A"
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
         }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": panel.title,
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "panels": dash.panels,
+    "refresh": false,
+    "schemaVersion": 22,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
         {
-          "format": panel.format,
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MKCZcgjnz"
+          },
+          "definition": "label_values(cluster_name)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "Cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(cluster_name)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MKCZcgjnz"
+          },
+          "definition": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "hostname",
+          "options": [],
+          "query": {
+            "query": "label_values({cluster_name=~\"$Cluster\"},hostname)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
         }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-   },
-   "Dashboard": {
-      local dash = self,
-      "annotations": {
-         "list": [
-            {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-            }
-         ]
-      },
-      "editable": true,
-      "gnetId": null,
-      "graphTooltip": 0,
-      "id": 1,
-      "links": [],
-      "panels": dash.panels,
-      "refresh": false,
-      "schemaVersion": 22,
-      "style": "dark",
-      "tags": [],
-      "templating": {
-         "list": []
-      },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
-      },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ]
-      },
-      "timezone": "",
-      "title": dash.title,
-      "uid": dash.uid,
-      "version": 2
-   }
+      ]
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": dash.title,
+    "uid": dash.uid,
+    "version": 2
+  }
 }

--- a/grafana-dashboard/grafana-dashboard-layers.jsonnet
+++ b/grafana-dashboard/grafana-dashboard-layers.jsonnet
@@ -1,67 +1,70 @@
 local lib = import 'grafana-dashboard-func.libsonnet';
 
-local ReadWritePanels(id, y, title, format, expr) = [
+local ReadWritePanels(id, y, title, format, expr, legend) = [
    lib.Panel{
      id: id, x: 0, y: y, 
      title: title + " (Read)", 
      format: format,
-     expr: std.strReplace(std.strReplace(expr, "LSOMIOTYPE", "read"), "IOTYPE", "read")
+     expr: std.strReplace(std.strReplace(expr, "LSOMIOTYPE", "read"), "IOTYPE", "read"),
+     legend: legend
    },
    lib.Panel{
      id: id + 1, x: 12, y: y, 
      title: title + " (Write)", 
      format: format,
-     expr: std.strReplace(std.strReplace(expr,  "LSOMIOTYPE", "write"), "IOTYPE", "write")
+     expr: std.strReplace(std.strReplace(expr,  "LSOMIOTYPE", "write"), "IOTYPE", "write"),
+     legend: legend
    },
 ];
 
-local Panels(id, y, title, format, expr) = [
+local Panels(id, y, title, format, expr, legend) = [
    lib.Panel{
      id: id, x: 0, y: y, 
      title: title, 
      format: format,
-     expr: expr
+     expr: expr,
+     legend: legend
    },
 ];
 
-local ReadWriteLayersPanels(id, y, title, format, domexpr, domdgexpr,lsomcacheexpr) = 
-  ReadWritePanels(id + 0, y +  0, "DOM Client " + title, format, std.strReplace(domexpr,  "ROLE", "client")) + 
-  ReadWritePanels(id + 2, y +  8, "DOM Owner " + title, format, std.strReplace(domexpr,  "ROLE", "owner")) + 
-  ReadWritePanels(id + 4, y + 16, "DOM Owner Leaf " + title, format, std.strReplace(domexpr,  "ROLE", "ownerLeaf")) +
-  ReadWritePanels(id + 6, y + 24, "DOM CompMgr " + title, format, std.strReplace(domexpr,  "ROLE", "compmgr")) +
-  ReadWritePanels(id + 8, y + 32, "DOM CompMgr DG " + title, format, domdgexpr) + 
-  ReadWritePanels(id + 10, y + 40, "LSOM Cache " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "cache")) +
-  ReadWritePanels(id + 12, y + 48, "LSOM Capacity " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "capacity")); 
+local ReadWriteLayersPanels(id, y, title, format, domexpr, domdgexpr, lsomcacheexpr) = 
+  ReadWritePanels(id + 0, y +  0, "DOM Client " + title, format, std.strReplace(domexpr,  "ROLE", "client"), "{{hostname}}") + 
+  ReadWritePanels(id + 2, y +  8, "DOM Owner " + title, format, std.strReplace(domexpr,  "ROLE", "owner"), "{{hostname}}") + 
+  ReadWritePanels(id + 4, y + 16, "DOM Owner Leaf " + title, format, std.strReplace(domexpr,  "ROLE", "ownerLeaf"), "{{hostname}}") +
+  ReadWritePanels(id + 6, y + 24, "DOM CompMgr " + title, format, std.strReplace(domexpr,  "ROLE", "compmgr"), "{{hostname}}") +
+  ReadWritePanels(id + 8, y + 32, "DOM CompMgr DG " + title, format, domdgexpr, "{{hostname}}, disk_uuid={{disk_uuid}}") + 
+  ReadWritePanels(id + 10, y + 40, "LSOM Cache " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "cache"), "{{hostname}}, disk_uuid={{disk_uuid}}") +
+  ReadWritePanels(id + 12, y + 48, "LSOM Capacity " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "capacity"), "{{hostname}}, disk_uuid={{disk_uuid}}"); 
 
-local ReadWriteLayersPanelsWithOutOwnerLeaf(id, y, title, format, domexpr, domdgexpr,lsomcacheexpr) =
-  ReadWritePanels(id + 0, y +  0, "DOM Client " + title, format, std.strReplace(domexpr,  "ROLE", "client")) +
-  ReadWritePanels(id + 2, y +  8, "DOM Owner " + title, format, std.strReplace(domexpr,  "ROLE", "owner")) +
-  ReadWritePanels(id + 4, y + 16, "DOM CompMgr " + title, format, std.strReplace(domexpr,  "ROLE", "compmgr")) +
-  ReadWritePanels(id + 6, y + 24, "DOM CompMgr DG " + title, format, domdgexpr) +
-  ReadWritePanels(id + 8, y + 32, "LSOM Cache " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "cache")) +
-  ReadWritePanels(id + 10, y + 40, "LSOM Capacity " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "capacity"));
+local ReadWriteLayersPanelsWithOutOwnerLeaf(id, y, title, format, domexpr, domdgexpr, lsomcacheexpr) =
+  ReadWritePanels(id + 0, y +  0, "DOM Client " + title, format, std.strReplace(domexpr,  "ROLE", "client"), "{{hostname}}") +
+  ReadWritePanels(id + 2, y +  8, "DOM Owner " + title, format, std.strReplace(domexpr,  "ROLE", "owner"), "{{hostname}}") +
+  ReadWritePanels(id + 4, y + 16, "DOM CompMgr " + title, format, std.strReplace(domexpr,  "ROLE", "compmgr"), "{{hostname}}") +
+  ReadWritePanels(id + 6, y + 24, "DOM CompMgr DG " + title, format, domdgexpr, "{{hostname}}") +
+  ReadWritePanels(id + 8, y + 32, "LSOM Cache " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "cache"), "{{hostname}}") +
+  ReadWritePanels(id + 10, y + 40, "LSOM Capacity " + title, format, std.strReplace(lsomcacheexpr, "DISKROLE", "capacity"),  "{{hostname}}, disk_uuid={{disk_uuid}}");
 
 local LayersPanels(id, y, title, format, expr) = 
-  Panels(id + 0, y +  0, "DOM Client " + title, format, std.strReplace(expr,  "ROLE", "client")) + 
-  Panels(id + 2, y +  8, "DOM Owner " + title, format, std.strReplace(expr,  "ROLE", "owner")) + 
-  Panels(id + 4, y + 16, "DOM CompMgr " + title, format, std.strReplace(expr,  "ROLE", "compmgr")); 
+  Panels(id + 0, y +  0, "DOM Client " + title, format, std.strReplace(expr,  "ROLE", "client"), "{{hostname}}") + 
+  Panels(id + 2, y +  8, "DOM Owner " + title, format, std.strReplace(expr,  "ROLE", "owner"), "{{hostname}}") + 
+  Panels(id + 4, y + 16, "DOM CompMgr " + title, format, std.strReplace(expr,  "ROLE", "compmgr"), "{{hostname}}"); 
 
 local step = 56;
 local panels = 
   ReadWriteLayersPanels(10, step * 0, "Latency", "s", 
-    "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ROLE\", io_type=\"IOTYPE\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ROLE\", io_type=\"IOTYPE\"}[1m]) +1) by (hostname, io_type, role)",
-    "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"IOTYPE\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
-    "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"DISKROLE\",io_type=\"LSOMIOTYPE\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"DISKROLE\", io_type=\"LSOMIOTYPE\"}[1m]) +1) by (hostname, disk_uuid, io_type)") +
+    "sum(rate(vmware_vsan_dom_io_duration_seconds_total{role=\"ROLE\", io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ROLE\", io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, io_type, role)",
+    "sum(rate(vmware_vsan_domdg_io_duration_seconds_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\", io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)",
+    "sum(rate(vmware_vsan_disks_dev_duration_seconds_total{disk_role=\"DISKROLE\",io_type=\"LSOMIOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type) / sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"DISKROLE\", io_type=\"LSOMIOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, disk_uuid, io_type)") +
   ReadWriteLayersPanels(30, step * 1, "IOPS", "short", 
-    "sum(rate(vmware_vsan_dom_io_total{role=\"ROLE\", io_type=\"IOTYPE\"}[1m])) by (hostname, io_type, role)",
-    "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid, io_type)",
-    "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"DISKROLE\",io_type=\"LSOMIOTYPE\"}[1m])) by (hostname, disk_uuid, io_type)") +
+    "sum(rate(vmware_vsan_dom_io_total{role=\"ROLE\", io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+    "sum(rate(vmware_vsan_domdg_io_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+    "sum(rate(vmware_vsan_disks_dev_io_total{disk_role=\"DISKROLE\",io_type=\"LSOMIOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)") +
   ReadWriteLayersPanelsWithOutOwnerLeaf(50, step * 2, "Tput", "Bps",
-    "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"ROLE\", io_type=\"IOTYPE\"}[1m])) by (hostname, io_type, role)",
-    "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"IOTYPE\"}[1m])) by (hostname, disk_uuid, io_type)",
-    "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"DISKROLE\",io_type=\"LSOMIOTYPE\"}[1m])) by (hostname, disk_uuid, io_type)") +
+    "sum(rate(vmware_vsan_dom_io_bytes_total{role=\"ROLE\", io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, io_type, role)",
+    "sum(rate(vmware_vsan_domdg_io_bytes_total{disk_role=\"cache\",io_type=\"IOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)",
+    "sum(rate(vmware_vsan_disks_dev_bytes_total{disk_role=\"DISKROLE\",io_type=\"LSOMIOTYPE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, disk_uuid, io_type)") +
   LayersPanels(70, step * 3, "OIO", "short", 
-    "sum(rate(vmware_vsan_dom_numoio_total{role=\"ROLE\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ROLE\"}[1m]) +1) by (hostname, role)");
+    "sum(rate(vmware_vsan_dom_numoio_total{role=\"ROLE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m])) by (hostname, role) / sum(rate(vmware_vsan_dom_io_total{role=\"ROLE\",hostname=~\"$hostname\",cluster_name=~\"$Cluster\"}[1m]) +1) by (hostname, role)");
 
    # XXX: Add all the missing ones
 


### PR DESCRIPTION
Added hostname & cluster variables to the dashboard. This will allow users to narrow down the graphs to host and cluster, which is very helpful in large, multi-cluster environments.

The graph type was changed to timeseries which was introduced in Grafana 7. This graph type is more performant, and prettier.

Legends were added to panels so that they are easier to read, and narrowed down to the distinguishing values. For example, a panel legend can show the values by host, and disk UUID.

Lastly, the jsonnet was corrected for a typo. I have additional details in the comment.

Signed-off-by: joseph.davila <joseph.davila@2k.com>