### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r tests/requirements.txt
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
       - name: Run unittest test_token_setup
         env:
           PYTHONPATH: "${PYTHONPATH}:/vsan-prometheus-setup"
@@ -75,7 +75,7 @@ jobs:
           pip install -r tests/requirements.txt
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
       - name: Run unittest test_vsan_servicediscovery
         env:
           PYTHONPATH: "${PYTHONPATH}:/vsan-prometheus-servicediscovery"
@@ -117,7 +117,7 @@ jobs:
         run: |
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         if: ${{ success() }}
         uses: docker/setup-qemu-action@v1
@@ -155,7 +155,7 @@ jobs:
         run: |
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         if: ${{ success() }}
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r tests/requirements.txt
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Run unittest test_token_setup
         env:
           PYTHONPATH: "${PYTHONPATH}:/vsan-prometheus-setup"
@@ -75,7 +75,7 @@ jobs:
           pip install -r tests/requirements.txt
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Run unittest test_vsan_servicediscovery
         env:
           PYTHONPATH: "${PYTHONPATH}:/vsan-prometheus-servicediscovery"
@@ -117,7 +117,7 @@ jobs:
         run: |
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Set up QEMU
         if: ${{ success() }}
         uses: docker/setup-qemu-action@v1
@@ -155,7 +155,7 @@ jobs:
         run: |
           SHORT_SHAR=$(git rev-parse --short HEAD)
           TAGS="github-${SHORT_SHAR}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Set up QEMU
         if: ${{ success() }}
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


